### PR TITLE
crash if not enabled special permissions and hasSpecialPipPermission()

### DIFF
--- a/android/src/main/java/com/reactpiplibrary/RNAndroidPipModule.java
+++ b/android/src/main/java/com/reactpiplibrary/RNAndroidPipModule.java
@@ -68,7 +68,7 @@ public class RNAndroidPipModule extends ReactContextBaseJavaModule implements Li
     }
     
     @ReactMethod
-    public boolean hasSpecialPipPermission(final Promise promise) {
+    public void hasSpecialPipPermission(final Promise promise) {
         AppOpsManager manager = (AppOpsManager) reactContext.getSystemService(Context.APP_OPS_SERVICE);
         if (manager != null) {
             int modeAllowed = manager.checkOpNoThrow(AppOpsManager.OPSTR_PICTURE_IN_PICTURE, Process.myUid(),


### PR DESCRIPTION
Fixes #3

Also adding new method:
```js
AndroidPip.hasSpecialPipPermission().then((enabled) => console.log('permissions enabled').catch(() => console.log('permissions not enabled');
```